### PR TITLE
Support multiple init code hashes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,7 @@ export const STAKING_REWARDS_FACTORY_ADDRESS: { [chainId: number]: string } = {
   [ChainId.ARBITRUM_TESTNET_V3]: '0xB95Ad562EDE8DD78BBFC287fA18150e802b09D9F',
   [ChainId.SOKOL]: '0xD436e756Cf41318ADeC62E8dCbEF2608753Ae068',
   [ChainId.XDAI]: '0xCD2A45F36464FdB1065160e03A2353996Ea8Ff57',
-  [ChainId.MATIC]: '',
+  [ChainId.MATIC]: '0x0000000000000000000000000000000000001234',
 }
 
 export const TOKEN_REGISTRY_ADDRESS: { [chainId: number]: string } = {
@@ -79,7 +79,7 @@ export const TOKEN_REGISTRY_ADDRESS: { [chainId: number]: string } = {
   [ChainId.ARBITRUM_TESTNET_V3]: '0x9d6f6d86b81289e40e07fcda805c06f6e9b8f629',
   [ChainId.SOKOL]: '0x681c3836a5589b933062ACA4fd846c1287a2865F',
   [ChainId.XDAI]: '0x85E001DfFF16F388Bc32Cd18009ceDF8F9b62C9E',
-  [ChainId.MATIC]: '',
+  [ChainId.MATIC]: '0x0000000000000000000000000000000000001234',
 }
 
 export const DXSWAP_TOKEN_LIST_ID: { [chainId: number]: number } = {
@@ -91,7 +91,10 @@ export const DXSWAP_TOKEN_LIST_ID: { [chainId: number]: number } = {
   [ChainId.MATIC]: 137
 }
 
-export const INIT_CODE_HASH = '0xd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776'
+export const INIT_CODE_HASH: { [chainId: number]: string } = {
+  [ChainId.XDAI]: '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93',
+  [ChainId.MATIC]: '0x5d5dfa98b23ace472a8581d664cd33b83c335db3009d1477c491e1cda864ad63',
+}
 
 export const MINIMUM_LIQUIDITY = JSBI.BigInt(1000)
 

--- a/src/entities/pair.ts
+++ b/src/entities/pair.ts
@@ -50,9 +50,6 @@ let PAIR_ADDRESS_CACHE: {
   },
   [RoutablePlatform.BAOSWAP.name]: {
     ...INITIAL_CACHE_STATE
-  },
-  [RoutablePlatform.LEVINSWAP.name]: {
-    ...INITIAL_CACHE_STATE
   }
 }
 
@@ -92,7 +89,7 @@ export class Pair {
               [tokens[1].address]: getCreate2Address(
                 platform.factoryAddress[chainId] as string,
                 keccak256(['bytes'], [pack(['address', 'address'], [tokens[0].address, tokens[1].address])]),
-                platform.initCodeHash
+                platform.initCodeHash[chainId] as string,
               )
             }
           }
@@ -117,7 +114,7 @@ export class Pair {
 
     this.platform = platform ? platform : RoutablePlatform.SWAPR
     const liquidityTokenAddress = Pair.getAddress(tokenAmounts[0].token, tokenAmounts[1].token, platform)
-    this.liquidityToken = new Token(tokenAmounts[0].token.chainId, liquidityTokenAddress, 18, 'DXS', 'DXswap')
+    this.liquidityToken = new Token(tokenAmounts[0].token.chainId, liquidityTokenAddress, 18, 'HNS', 'HoneySwap')
     this.protocolFeeDenominator = protocolFeeDenominator ? protocolFeeDenominator : defaultProtocolFeeDenominator
     this.tokenAmounts = tokenAmounts as [TokenAmount, TokenAmount]
     this.swapFee = swapFee ? swapFee : platform.defaultSwapFee

--- a/src/entities/routable-platform.ts
+++ b/src/entities/routable-platform.ts
@@ -2,16 +2,14 @@ import { BigintIsh, ChainId, defaultSwapFee, FACTORY_ADDRESS, INIT_CODE_HASH, RO
 
 const UNISWAP_FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
 const SUSHISWAP_FACTORY_ADDRESS = '0xC0AEe478e3658e2610c5F7A4A2E1777cE9e4f2Ac'
-const HONEYSWAP_FACTORY_ADDRESS = '0xA818b4F111Ccac7AA31D0BCc0806d64F2E0737D7'
+const SWAPR_FACTORY_ADDRESS = '0x5D48C95AdfFD4B40c1AAADc4e08fc44117E02179'
 const BAOSWAP_FACTORY_ADDRESS = '0x45de240fbe2077dd3e711299538a09854fae9c9b'
-const LEVINSWAP_FACTORY_ADDRESS = '0x965769C9CeA8A7667246058504dcdcDb1E2975A5'
 const QUICKSWAP_FACTORY_ADDRESS = '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32'
 
 const UNISWAP_ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
 const SUSHISWAP_ROUTER_ADDRESS = '0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F'
-const HONEYSWAP_ROUTER_ADDRESS = '0x1C232F01118CB8B424793ae03F870aa7D0ac7f77'
+const SWAPR_ROUTER_ADDRESS = '0xE43e60736b1cb4a75ad25240E2f9a62Bff65c0C0'
 const BAOSWAP_ROUTER_ADDRESS = '0x6093AeBAC87d62b1A5a4cEec91204e35020E38bE'
-const LEVINSWAP_ROUTER_ADDRESS = '0xb18d4f69627F8320619A696202Ad2C430CeF7C53'
 const QUICKSWAP_ROUTER_ADDRESS = '0xa5E0829CaCEd8fFDD4De3c43696c57F7D7A678ff'
 
 
@@ -22,11 +20,11 @@ export class RoutablePlatform {
   public readonly name: string
   public readonly factoryAddress: { [supportedChainId in ChainId]?: string }
   public readonly routerAddress: { [supportedChainId in ChainId]?: string }
-  public readonly initCodeHash: string
+  public readonly initCodeHash : { [supportedChainId in ChainId]?: string }
   public readonly defaultSwapFee: BigintIsh
 
-  public static readonly SWAPR = new RoutablePlatform(
-    'Swapr',
+  public static readonly HONEYSWAP = new RoutablePlatform(
+    'Honeyswap',
     FACTORY_ADDRESS,
     ROUTER_ADDRESS,
     INIT_CODE_HASH,
@@ -36,42 +34,35 @@ export class RoutablePlatform {
     'Uniswap',
     { [ChainId.MAINNET]: UNISWAP_FACTORY_ADDRESS, [ChainId.RINKEBY]: UNISWAP_FACTORY_ADDRESS },
     { [ChainId.MAINNET]: UNISWAP_ROUTER_ADDRESS, [ChainId.RINKEBY]: UNISWAP_ROUTER_ADDRESS },
-    '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+    { [ChainId.MAINNET]: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' },
     _30
   )
   public static readonly SUSHISWAP = new RoutablePlatform(
     'Sushiswap',
     { [ChainId.MAINNET]: SUSHISWAP_FACTORY_ADDRESS, [ChainId.RINKEBY]: SUSHISWAP_FACTORY_ADDRESS },
     { [ChainId.MAINNET]: SUSHISWAP_ROUTER_ADDRESS, [ChainId.RINKEBY]: SUSHISWAP_ROUTER_ADDRESS },
-    '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303',
+    { [ChainId.MAINNET]: '0xe18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303' },
     _30
   )
-  public static readonly HONEYSWAP = new RoutablePlatform(
-    'Honeyswap',
-    { [ChainId.XDAI]: HONEYSWAP_FACTORY_ADDRESS },
-    { [ChainId.XDAI]: HONEYSWAP_ROUTER_ADDRESS },
-    '0x3f88503e8580ab941773b59034fb4b2a63e86dbc031b3633a925533ad3ed2b93',
+  public static readonly SWAPR = new RoutablePlatform(
+    'Swapr',
+    { [ChainId.XDAI]: SWAPR_FACTORY_ADDRESS },
+    { [ChainId.XDAI]: SWAPR_ROUTER_ADDRESS },
+    { [ChainId.XDAI]: '0xd306a548755b9295ee49cc729e13ca4a45e00199bbd890fa146da43a50571776' },
     _30
   )
   public static readonly BAOSWAP = new RoutablePlatform(
     'Baoswap',
     { [ChainId.XDAI]: BAOSWAP_FACTORY_ADDRESS },
     { [ChainId.XDAI]: BAOSWAP_ROUTER_ADDRESS },
-    '0x0bae3ead48c325ce433426d2e8e6b07dac10835baec21e163760682ea3d3520d',
-    _30
-  )
-  public static readonly LEVINSWAP = new RoutablePlatform(
-    'Levinswap',
-    { [ChainId.XDAI]: LEVINSWAP_FACTORY_ADDRESS },
-    { [ChainId.XDAI]: LEVINSWAP_ROUTER_ADDRESS },
-    '0x4955fd9146732ca7a64d43c7a8d65fe6db1acca27e9c5b3bee7c3abe5849f441',
+    { [ChainId.XDAI]: '0x0bae3ead48c325ce433426d2e8e6b07dac10835baec21e163760682ea3d3520d' },
     _30
   )
   public static readonly QUICKSWAP = new RoutablePlatform(
     'Quickswap',
     { [ChainId.MATIC]: QUICKSWAP_FACTORY_ADDRESS },
     { [ChainId.MATIC]: QUICKSWAP_ROUTER_ADDRESS },
-    '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f',
+    { [ChainId.MATIC]: '0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' },
     _30
   )
 
@@ -79,7 +70,7 @@ export class RoutablePlatform {
     name: string,
     factoryAddress: { [supportedChainId in ChainId]?: string },
     routerAddress: { [supportedChainId in ChainId]?: string },
-    initCodeHash: string,
+    initCodeHash: { [supportedChainId in ChainId]?: string },
     defaultSwapFee: BigintIsh
   ) {
     this.name = name


### PR DESCRIPTION
Given that our Matic and xDai deployments have different init code hashes, we need to update the codebase accordinly.