### PR TITLE
feat: Update polygon tokenlist url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dxswap-sdk",
   "license": "AGPL-3.0-or-later",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "An SDK for building applications on top of DXswap.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -375,7 +375,7 @@ export abstract class Fetcher {
     const tokenListUrl = new Map([
       [1, 'https://tokens.coingecko.com/uniswap/all.json'],
       [100, 'https://tokens.honeyswap.org'],
-      [137, 'https://unpkg.com/quickswap-default-token-list@1.0.55/build/quickswap-default.tokenlist.json']
+      [137, 'https://tokens.honeyswap.org']
     ])
 
     // const tokenRegistryContract = new Contract(TOKEN_REGISTRY_ADDRESS[chainId], TokenRegistryAbi, provider)


### PR DESCRIPTION
From now on, we will use `tokens.honeyswap.org` to fetch Polygon tokens. We now support both networks on our official token list.