### PR TITLE
Correct WETH token address on Polygon/Matic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dxswap-sdk",
   "license": "AGPL-3.0-or-later",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "An SDK for building applications on top of DXswap.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -48,7 +48,7 @@ export class Token extends Currency {
     ),
     [ChainId.MATIC]: new Token(
       ChainId.MATIC,
-      '0x8cc8538d60901d19692F5ba22684732Bc28F54A3',
+      '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
       18,
       'WETH',
       'Wrapped Ether on Matic'


### PR DESCRIPTION
This bug caused https://github.com/1Hive/honeyswap/issues/77

Requires an update in https://github.com/1Hive/honeyswap-interface to redeploy with the new SDK version.