### PR TITLE
Fix Honeyswap swap fee

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dxswap-sdk",
   "license": "AGPL-3.0-or-later",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "An SDK for building applications on top of DXswap.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/entities/routable-platform.ts
+++ b/src/entities/routable-platform.ts
@@ -28,7 +28,7 @@ export class RoutablePlatform {
     FACTORY_ADDRESS,
     ROUTER_ADDRESS,
     INIT_CODE_HASH,
-    defaultSwapFee
+    _30
   )
   public static readonly UNISWAP = new RoutablePlatform(
     'Uniswap',


### PR DESCRIPTION
The interface incorrectly reports 0.25% as the fee per swap when it is in fact 0.3%